### PR TITLE
ルーム参加用QRコード読み取り画面の実装（ハリボテ）

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import MakeQuestion from "./components/MakeQuestion";
 import MyProfile from "./components/MyProfile";
 import EditProfile from "./components/EditProfile";
+import ReadQRCode from "./components/ReadQRCode";
 
 
 

--- a/src/components/ReadQRCode.jsx
+++ b/src/components/ReadQRCode.jsx
@@ -1,0 +1,49 @@
+//将来的な置き換え
+// handleMockScan関数→実際のQRコード読み取り処理
+//mockRoomId→QRコード解析結果
+//alert→ルーム画面遷移orstate管理
+
+import { useState } from "react";
+
+export default function ReadQRCode() {
+  const [scanned, setScanned] = useState(false);
+  const [roomId, setRoomId] = useState(null);
+
+  const handleMockScan = () => {
+    const mockRoomId = "ROOM-1234";
+    setRoomId(mockRoomId);
+    setScanned(true);
+  };
+
+  return (
+    <div>
+      <h1>ルームに参加</h1>
+
+      {!scanned && (
+        <div>
+          <p>QRコードをカメラ枠の中に合わせてください</p>
+
+          <div>
+            <p>（ここにカメラ映像が表示されます）</p>
+            <p>［ QRコード読み取りエリア ］</p>
+          </div>
+
+          <button onClick={handleMockScan}>
+            QRを読み取ったことにする（仮）
+          </button>
+        </div>
+      )}
+
+      {scanned && (
+        <div>
+          <p>QRコードを読み取りました！</p>
+          <p>ルームID: {roomId}</p>
+
+          <button onClick={() => alert("ルーム参加処理へ")}>
+            ルームに参加する
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
ルーム参加時にQRコードを読み込む画面を作成（カメラ対応はしてないです）
将来的には現在のルームID入力画面の代わりになるはず