### PR TITLE
QRコード読み取り画面にURL直打ちでアクセス可能に

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,6 +49,8 @@ function App() {
         <Route path="/make_question" element={<MakeQuestion />} />
         <Route path="/my_profile" element={<MyProfile />} />
         <Route path="/edit_profile" element={<EditProfile />} />
+        <Route path="/read_qr" element={<ReadQRCode />} />
+
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
ローカルホストのリンクの後に/read_qrと打ったらQR読み取り画面のハリボテが見れます
